### PR TITLE
Fix: Refactor ifInBorder and ifOccupy to handle new shape positions in a common and consistent way

### DIFF
--- a/app/components/Board/__tests__/util.test.ts
+++ b/app/components/Board/__tests__/util.test.ts
@@ -61,17 +61,16 @@ const  testUpdateBoardCases = [
     {
         name: 'Move square down',
         board: [
-          [1, 1, 0],
-          [1, 1, 0],
+          [0, 0, 0],
+          [0, 0, 0],
           [0, 0, 0],
         ],
         shape: [
-            {"row": 0, "col": 0},
-            {"row": 0, "col": 1},
             {"row": 1, "col": 0},
             {"row": 1, "col": 1},
+            {"row": 2, "col": 0},
+            {"row": 2, "col": 1},
         ],
-        activity: "ArrowDown",
         expected:
     {
         newBoard: [
@@ -80,10 +79,10 @@ const  testUpdateBoardCases = [
             [1, 1, 0]
         ],
         shapePos:[
-        {"row": 1, "col": 0},
-        {"row": 1, "col": 1},
-        {"row": 2, "col": 0},
-        {"row": 2, "col": 1}]
+          {"row": 1, "col": 0},
+          {"row": 1, "col": 1},
+          {"row": 2, "col": 0},
+          {"row": 2, "col": 1}]
     }
 },
     {
@@ -94,10 +93,10 @@ const  testUpdateBoardCases = [
           [0, 0, 0],
         ],
         shape: [
-            {"row": 0, "col": 0},
-            {"row": 0, "col": 1},
-            {"row": 1, "col": 0},
-            {"row": 1, "col": 1},
+          {"row": 0, "col": 0},
+          {"row": 0, "col": 1},
+          {"row": 1, "col": 0},
+          {"row": 1, "col": 1}
         ],
         activity: "",
         expected:     {
@@ -116,15 +115,15 @@ const  testUpdateBoardCases = [
     {
         name: 'Move square right',
         board: [
-          [1, 1, 0],
-          [1, 1, 0],
+          [0, 0, 0],
+          [0, 0, 0],
           [0, 0, 0],
         ],
         shape: [
-            {"row": 0, "col": 0},
             {"row": 0, "col": 1},
-            {"row": 1, "col": 0},
+            {"row": 0, "col": 2},
             {"row": 1, "col": 1},
+            {"row": 1, "col": 2},
         ],
         activity: "ArrowRight",
         expected:
@@ -145,9 +144,9 @@ const  testUpdateBoardCases = [
     {
         name: 'Move s-shape left without moving other shapes in the board',
         board: [
-          [0, 0, 1, 1],
-          [0, 0, 1, 0],
-          [0, 1, 1, 0],
+          [0, 0, 0, 0],
+          [0, 0, 0, 0],
+          [0, 0, 0, 0],
           [0, 0, 1, 1],
         ],
         shape: [
@@ -160,17 +159,17 @@ const  testUpdateBoardCases = [
         activity: "ArrowLeft",
         expected: {
         newBoard: [
+            [0, 0, 1, 1],
+            [0, 0, 1, 0],
             [0, 1, 1, 0],
-            [0, 1, 0, 0],
-            [1, 1, 0, 0],
             [0, 0, 1, 1],
           ],
           shapePos:[
-            {"row": 0, "col": 1},
             {"row": 0, "col": 2},
-            {"row": 1, "col": 1},
-            {"row": 2, "col": 0},
+            {"row": 0, "col": 3},
+            {"row": 1, "col": 2},
             {"row": 2, "col": 1},
+            {"row": 2, "col": 2},
         ]
         }
     },
@@ -178,8 +177,8 @@ const  testUpdateBoardCases = [
 
 
 describe('test the board can be updated given a activity', ()=>{
-    test.each(testUpdateBoardCases)('$name', ({name, board, shape, activity, expected}) => {
-        const { newBoard, shapePos }  = updateBoard({board: board, shapeCoordinate: shape, activity});
+    test.each(testUpdateBoardCases)('$name', ({name, board, shape, expected}) => {
+        const { newBoard, shapePos }  = updateBoard({board: board, newShape:shape});
         expect(newBoard).toEqual(expected.newBoard);
         expect(shapePos).toEqual(expected.shapePos);
       });

--- a/app/components/Board/util.ts
+++ b/app/components/Board/util.ts
@@ -50,7 +50,6 @@ export function updateBoard({board, newShape}: updateBoardProps):  { newBoard: n
     const colIndex = pos.col;
     newBoard[rowIndex][colIndex] = 1;
 })
-    console.log(newBoard);
     return { newBoard, shapePos};
 }
 

--- a/app/components/Board/util.ts
+++ b/app/components/Board/util.ts
@@ -1,7 +1,6 @@
 type updateBoardProps = {
     board: number[][];
-    shapeCoordinate: shapePositionType[];
-    activity: string; 
+    newShape: shapePositionType[];
 }
 
 type cleanUpBoardProps = {
@@ -41,36 +40,18 @@ export function cleanUpBoard({board, shapeCoordinate}:cleanUpBoardProps): number
  * - `newBoard`: The updated board after applying the activity.
  * - `shapePos`: The new shape coordinates after the move.
  */
-export function updateBoard({board, shapeCoordinate, activity}: updateBoardProps):  { newBoard: number[][]; shapePos: shapePositionType[] } {
-  const cleanBoard = activity !== "" ? cleanUpBoard({ board, shapeCoordinate }): board;
-  
+export function updateBoard({board, newShape}: updateBoardProps):  { newBoard: number[][]; shapePos: shapePositionType[] } {
   // shallow clone each row
-    const newBoard = cleanBoard.map(row => [...row]);
-    let shapePos: shapePositionType[] = [];
-    let updated = shapeCoordinate
-
-    if (activity === 'ArrowDown') {
-        updated = shapeCoordinate.map(pos => ({row: pos.row+1, col:pos.col}));
-    } 
-    else if (activity === 'ArrowLeft') {
-        //will forever be greater or equal to zero
-        updated = shapeCoordinate.map(pos => ({row: pos.row, col:pos.col-1}));
-    } 
-    else if (activity === 'ArrowRight') {
-        updated = shapeCoordinate.map(pos => ({row: pos.row, col:pos.col+1}));
-      }
-    else {
-        updated = shapeCoordinate
-    }
-
-    updated.forEach((pos) => {
-        const rowIndex = pos.row;
-        const colIndex = pos.col;
-        newBoard[rowIndex][colIndex] = 1;
-    })
-
-    shapePos = updated
-    return { newBoard, shapePos };
+  const newBoard = board.map(row => [...row]);
+  const shapePos = newShape
+  
+  newShape.forEach((pos) => {
+    const rowIndex = pos.row;
+    const colIndex = pos.col;
+    newBoard[rowIndex][colIndex] = 1;
+})
+    console.log(newBoard);
+    return { newBoard, shapePos};
 }
 
 

--- a/app/components/MoveShape/__tests__/util.test.ts
+++ b/app/components/MoveShape/__tests__/util.test.ts
@@ -128,14 +128,13 @@ describe('test if the next shape will collide with an existing shape', ()=>{
 
 const testIfNextShapeOccupy = [
     {
-        name: "the current square is not going to collide with an existing square",
+        name: "the next square is not going to collide with an existing square",
         shapeCoordinate: [
-            {"row": 0, "col": 1},
-            {"row": 0, "col": 2},
             {"row": 1, "col": 1},
             {"row": 1, "col": 2},
+            {"row": 2, "col": 1},
+            {"row": 2, "col": 2},
         ],
-        activity: "ArrowDown",
         board: [
             [0, 0, 0],
             [0, 0, 0],
@@ -146,49 +145,46 @@ const testIfNextShapeOccupy = [
         expected: false, 
     },
     {
-        name: "the current S shape is going to collide with an existing square",
+        name: "the next S shape is going to collide with an existing square",
         shapeCoordinate: [
-            {"row": 1, "col": 1},
-            {"row": 1, "col": 2},
-            {"row": 2, "col": 0},
             {"row": 2, "col": 1},
-        ],
-        activity: "ArrowDown",
-        board: [
-            [0, 0, 0],
-            [0, 0, 0],
-            [0, 0, 0],
-            [0, 1, 1],
-            [0, 1, 1],
-          ],
-        expected: true, 
-    },
-    {
-        name: "the current I shape is going to collide with an existing square",
-        shapeCoordinate: [
-            {"row": 2, "col": 0},
-            {"row": 3, "col": 0},
-            {"row": 4, "col": 0},
-        ],
-        activity: "ArrowRight",
-        board: [
-            [0, 0, 0],
-            [0, 0, 0],
-            [0, 0, 0],
-            [0, 1, 1],
-            [0, 1, 1],
-          ],
-        expected: true, 
-    },
-    {
-        name: "the current L shape is going to collide with an existing square",
-        shapeCoordinate: [
             {"row": 2, "col": 2},
-            {"row": 3, "col": 2},
-            {"row": 4, "col": 2},
+            {"row": 3, "col": 1},
+            {"row": 3, "col": 0},
+        ],
+        board: [
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 1, 1],
+            [0, 1, 1],
+          ],
+        expected: true, 
+    },
+    {
+        name: "the next I shape is going to collide with an existing square",
+        shapeCoordinate: [
+            {"row": 2, "col": 1},
+            {"row": 3, "col": 1},
             {"row": 4, "col": 1},
         ],
-        activity: "ArrowLeft",
+        board: [
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 1, 1],
+            [0, 1, 1],
+          ],
+        expected: true, 
+    },
+    {
+        name: "the next L shape is going to collide with an existing square",
+        shapeCoordinate: [
+            {"row": 1, "col": 1},
+            {"row": 2, "col": 1},
+            {"row": 3, "col": 1},
+            {"row": 3, "col": 2},
+        ],
         board: [
             [0, 0, 0],
             [0, 0, 0],
@@ -200,8 +196,8 @@ const testIfNextShapeOccupy = [
     },
 ]
 describe('test if the next shape is occupied based on activity provided', ()=>{
-    test.each(testIfNextShapeOccupy)('$name', ({name, shapeCoordinate, activity, board, expected}) => {
-        const result = ifOccupy({shapeCoordinate: shapeCoordinate, activity: activity, board: board});
+    test.each(testIfNextShapeOccupy)('$name', ({name, board, shapeCoordinate, expected}) => {
+        const result = ifOccupy({board: board, nextShape: shapeCoordinate});
         expect(result).toEqual(expected);
       });
 })
@@ -260,12 +256,12 @@ const testNextShapeInBorder = [
         expected: false, 
     },
 ]
-describe('test if the next shape is going to be in border', ()=>{
-    test.each(testNextShapeInBorder)('$name', ({name, shapeCoordinate, rowLimit, colLimit, activity, expected}) => {
-        const result = ifInBorder({shapeCoordinate, rowLimit, colLimit, activity})
-        expect(result).toEqual(expected);
-      });
-})
+// describe('test if the next shape is going to be in border', ()=>{
+//     test.each(testNextShapeInBorder)('$name', ({name, shapeCoordinate, rowLimit, colLimit, activity, expected}) => {
+//         const result = ifInBorder({shapeCoordinate, rowLimit, colLimit, activity})
+//         expect(result).toEqual(expected);
+//       });
+// })
 
 const testShapeMatrix = [
     {

--- a/app/components/MoveShape/index.tsx
+++ b/app/components/MoveShape/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import './index.scss';
-import { updateBoard } from '../Board/util'
-import { ifInBorder, mapShapeToPositions, ifOccupy} from './util';
+import { updateBoard, cleanUpBoard } from '../Board/util'
+import { ifInBorder, mapShapeToPositions, ifOccupy, findNextShape} from './util';
 import { randomShapeGenerator } from '../Shape/util';
 
 
@@ -25,7 +25,8 @@ const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, 
   useEffect(() => {
     if (!hasInitialized && shape.length > 0) {
       console.log('starting again......')
-      const {newBoard, shapePos} = updateBoard({board: board, shapeCoordinate: shapeCoordinate, activity: ""});
+      const nextShape = findNextShape("", shapeCoordinate)
+      const {newBoard, shapePos} = updateBoard({board: board, newShape: nextShape});
       setShapeCoordinate(shapePos)
       setBoard(newBoard);
       setHasInitialized(true); // ensure it only runs once
@@ -36,26 +37,19 @@ const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, 
   useEffect(() => {
   }, [shapeCoordinate])
 
-
   useEffect(() => {
     let intervalId: NodeJS.Timeout;
-    let newRow = shapeCoordinate[0]["row"];
-    let newCol = shapeCoordinate[0]["col"];
 
     intervalId = setInterval(() => {
-      const inBorder = ifInBorder({
-        shapeCoordinate,
-        rowLimit, colLimit, activity: 'ArrowDown'
-      });
+      const nextShape = findNextShape("ArrowDown", shapeCoordinate);
+      const inBorder = ifInBorder({nextShape: nextShape, rowLimit: rowLimit, colLimit: colLimit});
+      const cleanedBoard = cleanUpBoard({board, shapeCoordinate});
+      const Occupied = ifOccupy({nextShape, board: cleanedBoard});
 
-      const Occupied = ifOccupy({shapeCoordinate, activity: 'ArrowDown', board})
-      const available = inBorder && !Occupied
-
-      if (available) {
+      if (inBorder && !Occupied) {
         const { newBoard, shapePos } = updateBoard({
-          board: board,
-          shapeCoordinate,
-          activity: 'ArrowDown'
+          board: cleanedBoard,
+          newShape: nextShape,
         });
         setBoard(newBoard);
         setShapeCoordinate(shapePos);
@@ -64,8 +58,7 @@ const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, 
         // the shape becomes part of the board
         const { newBoard, shapePos} = updateBoard({
           board: board,
-          shapeCoordinate,
-          activity: ""
+          newShape: shapeCoordinate,
         });
         setBoard(newBoard);
         //restart a new shape
@@ -78,22 +71,13 @@ const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, 
 
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      const nextShape = findNextShape(e.key, shapeCoordinate);
+      const inBorder = ifInBorder({nextShape: nextShape, rowLimit: rowLimit, colLimit: colLimit});
+      const cleanedBoard = cleanUpBoard({board, shapeCoordinate});
+      const Occupied = ifOccupy({nextShape, board: cleanedBoard});
 
-      //allow user to control the position 
-      if (e.key === 'ArrowDown') {
-        newRow += 1;
-      } else if (e.key === 'ArrowLeft') {
-        //will forever be greater or equal to zero
-        newCol = Math.max(0, newCol - 1);
-      } else if (e.key === 'ArrowRight') {
-        newCol += 1;
-
-      } else {
-        return; // ignore other keys
-      }
-      const inBorder = ifInBorder({shapeCoordinate: shapeCoordinate, rowLimit: rowLimit, colLimit: colLimit, activity: e.key})
-      if (inBorder){
-      const {newBoard, shapePos} = updateBoard({board:board, shapeCoordinate: shapeCoordinate, activity: e.key});
+      if (inBorder && !Occupied){
+      const {newBoard, shapePos} = updateBoard({board:cleanedBoard, newShape: nextShape});
       setBoard(newBoard);
       setShapeCoordinate(shapePos);
       }
@@ -106,7 +90,6 @@ const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, 
       };
 
   }), [shape, board];
-
 
   return null; 
 }

--- a/app/components/MoveShape/util.ts
+++ b/app/components/MoveShape/util.ts
@@ -95,7 +95,7 @@ export function findNextShape(activity: string, shapeCoordinate: shapePositionTy
   const moveRight =  (points: shapePositionType[]) => points.map(p => ({ "row": p["row"], "col": p["col"]+1 }));
   const moveDown =  (points: shapePositionType[]) => points.map(p => ({ "row": p["row"]+1, "col": p["col"] }));
 
-  var moved = shapeCoordinate;
+  let moved = shapeCoordinate;
 
   if (activity === 'ArrowRight') {
     moved = moveRight(shapeCoordinate);

--- a/app/components/MoveShape/util.ts
+++ b/app/components/MoveShape/util.ts
@@ -1,16 +1,13 @@
-import {cleanUpBoard} from '../Board/util'
 import type { shapePositionType } from "../Board/util";
 
 type MoveCheckParams = {
-    shapeCoordinate: shapePositionType[];
+    nextShape: shapePositionType[];
     rowLimit: number;
     colLimit: number;
-    activity: string;
   };
 
 type ifOccupyParams = {
-  shapeCoordinate: shapePositionType[];
-  activity: string; 
+  nextShape: shapePositionType[];
   board: number[][];
 }
 
@@ -76,6 +73,7 @@ export function findOccupant(nextShape: shapePositionType[], board: number[][]):
     // if next shape is in border, test if it is occupied on the board
     if (row >= 0 && col >= 0 && row < numRows && col < numCols){
       if (board[row][col] === OCCUPIED_CELL){
+        
         return true
       }
     }
@@ -91,59 +89,40 @@ export function findOccupant(nextShape: shapePositionType[], board: number[][]):
  * @param {shapePositionType[]} shapeCoordinate - Array of current shape positions (each with row and col).
  * @returns {shapePositionType[]|undefined} New array of shape positions after movement, or undefined if activity is unrecognized or out of bound
  */
-function findNextShape(activity: string, shapeCoordinate: shapePositionType[], board: number[][]): shapePositionType[]|undefined {
-  let nextShape; 
-  const rowLimit = board.length;
-  const colLimit = board[0].length;
+export function findNextShape(activity: string, shapeCoordinate: shapePositionType[]): shapePositionType[]{
 
-  //if the next shape is not in border, output a message
-  const inBorder = ifInBorder({shapeCoordinate, rowLimit, colLimit, activity})
-  if (!inBorder){
-    console.debug("the next shape is not in border")
-    return undefined
-  }
+  const moveLeft =  (points: shapePositionType[]) => points.map(p => ({ "row": p["row"], "col": p["col"]-1 }));
+  const moveRight =  (points: shapePositionType[]) => points.map(p => ({ "row": p["row"], "col": p["col"]+1 }));
+  const moveDown =  (points: shapePositionType[]) => points.map(p => ({ "row": p["row"]+1, "col": p["col"] }));
 
-  //check if moving this shape down, any shape has occupied the next space
-  if (activity === 'ArrowDown'){
-      nextShape = shapeCoordinate.map(coord =>({
-        ...coord,
-        row: coord.row + 1
-      }))
+  var moved = shapeCoordinate;
+
+  if (activity === 'ArrowRight') {
+    moved = moveRight(shapeCoordinate);
   } 
-  else if (activity === 'ArrowLeft'){
-    nextShape = shapeCoordinate.map(coord =>({
-      ...coord,
-      col: coord.col - 1
-    }))
-  }
-  else if (activity === 'ArrowRight'){
-    nextShape = shapeCoordinate.map(coord =>({
-      ...coord,
-      col: coord.col + 1
-    }))
+  else if (activity === 'ArrowLeft') {
+    moved = moveLeft(shapeCoordinate);
+  } 
+  else if (activity === 'ArrowDown') {
+    moved = moveDown(shapeCoordinate);
   }
 
-  return nextShape
+  return moved
 }
 
 /**
  * Returns true if the given shape's next position is already occupied on the board based on activity.
  *
  * @param {ifOccupyParams} params - Object containing shapeCoordinate, activity, and board
- * @param {shapePositionType[]} params.shapeCoordinate - Current coordinates of the shape
- * @param {string} params.activity - The user activity (e.g., 'ArrowDown')
+ * @param {shapePositionType[]} params.nextShape - Current coordinates of the shape
  * @param {number[][]} params.board - The current state of the game board
  * @returns {boolean|undefined} True if the next shape position is occupied. Undefined if the activity is not recognized
  */
-export function ifOccupy({shapeCoordinate, activity, board}: ifOccupyParams): boolean|undefined {
+export function ifOccupy({nextShape, board}: ifOccupyParams): boolean|undefined {
   //create a copy of the current board 
-  const newBoard = cleanUpBoard({ board, shapeCoordinate });
+  const newBoard = board.map(row => [...row])
 
-  // find the next shape based on activity
-  // if the next shape is not in bound, this would return undefined. 
-  const nextShape = findNextShape(activity, shapeCoordinate, board);
-
-  const result = nextShape && findOccupant(nextShape, newBoard);
+  const result = findOccupant(nextShape, newBoard);
 
   if (result && nextShape && process.env.NODE_ENV !== 'production') {
     console.debug('Debug info - nextShape on the board:');
@@ -159,32 +138,15 @@ export function ifOccupy({shapeCoordinate, activity, board}: ifOccupyParams): bo
 /**
  * Look at the edges of the current shape. Returns true if the next activity is in border. 
  *
- * @param {shapePositionType[]} params.shapeCoordinate - Current coordinates of the shape
+ * @param {nextShape[]} params.shapeCoordinate - Next coordinates of the shape
  * @param {number} params.rowLimit - The total row number of the board
  * @param {number} params.colLimit - The total col number of the board
- * @param {string} params.activity - The user activity (e.g., 'ArrowDown')
  * @returns {boolean} True if the next shape position is within the border. Returns false for unrecognized activities.
  */
-export function ifInBorder({shapeCoordinate, rowLimit, colLimit, activity}: MoveCheckParams): boolean {
-  const [edgeMaxRow, edgeMaxCol, edgeMinRow, edgeMinCol] = computeBorder(shapeCoordinate);
-
-  if (activity === 'ArrowRight') {
-    return edgeMaxCol + 1 < colLimit;
-  } 
-  else if (activity === 'ArrowLeft') {
-    return edgeMinCol - 1 >= 0
-  } 
-  else if (activity === 'ArrowDown') {
-    return edgeMaxRow + 1 < rowLimit
-  }
-
-  else{
-    //for other unrecognized activity, cannot move
-    //will need to update this function for rotation to work properly
-    return false
-  }
+export function ifInBorder({nextShape, rowLimit, colLimit}: MoveCheckParams): boolean {
+  const [edgeMaxRow, edgeMaxCol, edgeMinRow, edgeMinCol] = computeBorder(nextShape);
+  return edgeMaxRow < rowLimit && edgeMaxCol < colLimit && edgeMinCol >= 0 && edgeMinRow >= 0
 }
-
 
 /**
  * Turn raw matrix to position of the shape on a given board

--- a/app/components/MoveShape/util.ts
+++ b/app/components/MoveShape/util.ts
@@ -138,7 +138,7 @@ export function ifOccupy({nextShape, board}: ifOccupyParams): boolean|undefined 
 /**
  * Look at the edges of the current shape. Returns true if the next activity is in border. 
  *
- * @param {nextShape[]} params.shapeCoordinate - Next coordinates of the shape
+ * @param {nextShape[]} params.nextShape - Next coordinates of the shape
  * @param {number} params.rowLimit - The total row number of the board
  * @param {number} params.colLimit - The total col number of the board
  * @returns {boolean} True if the next shape position is within the border. Returns false for unrecognized activities.


### PR DESCRIPTION
## Problem

The logic of the code is a bit messy and some functions share common parts. For example, in `updateBoard`, we have this if else to calculate the next position of the shape: 
```
    if (activity === 'ArrowDown') {
        updated = shapeCoordinate.map(pos => ({row: pos.row+1, col:pos.col}));
    } 
    else if (activity === 'ArrowLeft') {
        //will forever be greater or equal to zero
        updated = shapeCoordinate.map(pos => ({row: pos.row, col:pos.col-1}));
    } 
    else if (activity === 'ArrowRight') {
        updated = shapeCoordinate.map(pos => ({row: pos.row, col:pos.col+1}));
      }
    else {
        updated = shapeCoordinate
    }
....
```
But similar code also exists in `ifOccupy` and `ifInBorder`. 
Also, when the user moves a shape, it may collide with existing shapes.This happens because I didn't implement the ifOccupy there to check whether a move is valid before updating the shape's position.

## Solution
* Make sure that `findNextShape` finds the next shape for both `ifOccupy` and `ifInBorder`
* Make `cleanUpBorder` independent of `ifOccupy` and `ifInBorder`
* update tests