### PR TITLE
feat: rotate shape within a box

### DIFF
--- a/app/components/Board/util.ts
+++ b/app/components/Board/util.ts
@@ -1,5 +1,3 @@
-import {rotateShape} from '../MoveShape/util'
-
 type updateBoardProps = {
     board: number[][];
     newShape: shapePositionType[];

--- a/app/components/MoveShape/__tests__/util.test.ts
+++ b/app/components/MoveShape/__tests__/util.test.ts
@@ -317,8 +317,62 @@ describe('test if shapes can be mapped to coordinates correctly', ()=>{
 
 const testRotateShape = [
     {
-        "name": "rotate I shape from horizontal to vertical",
-        "coordinate": [{"row": 1, "col": 1}, {"row": 2, "col": 1}, {"row": 3, "col": 1}, {"row": 4, "col": 1}],
+        "name": "rotate J shape from horizontal to vertical",
+        "box": [{
+                    "row": 0,
+                    "col": 0
+                },
+                {
+                    "row": 0,
+                    "col": 1
+                },
+                {
+                    "row": 0,
+                    "col": 2
+                },
+                {
+                    "row": 1,
+                    "col": 0
+                },
+                {
+                    "row": 1,
+                    "col": 1
+                },
+                {
+                    "row": 1,
+                    "col": 2
+                },
+                {
+                    "row": 2,
+                    "col": 0
+                },
+                {
+                    "row": 2,
+                    "col": 1
+                },
+                {
+                    "row": 2,
+                    "col": 2
+                }
+        ],
+        "coordinate": [
+                {
+                    "row": 1,
+                    "col": 0
+                },
+                {
+                    "row": 1,
+                    "col": 1
+                },
+                {
+                    "row": 1,
+                    "col": 2
+                },
+                {
+                    "row": 2,
+                    "col": 2
+                }
+        ],
         "board": [
             [0, 0, 0, 0],
             [0, 0, 0, 0],
@@ -327,11 +381,79 @@ const testRotateShape = [
             [0, 0, 0, 0],
             [0, 0, 0, 0],
         ],
-        "expected": [{"row": 2, "col": 0}, {"row": 2, "col": 1}, {"row": 2, "col": 2}, {"row": 2, "col": 3}],
+        "expected": [
+            {
+                "row": 0,
+                "col": 1
+            },
+            {
+                "row": 1,
+                "col": 1
+            },
+            {
+                "row": 2,
+                "col": 1
+            },
+            {
+                "row": 2,
+                "col": 0
+            }
+    ],
     },
     {
-        "name": "rotate I shape from vertical to horizontal",
-        "coordinate": [{"row": 2, "col": 0}, {"row": 2, "col": 1}, {"row": 2, "col": 2}, {"row": 2, "col": 3}],
+        "name": "rotate I shape",
+        "box": [
+            {
+                "row": 0,
+                "col": 0
+            },
+            {
+                "row": 0,
+                "col": 1
+            },
+            {
+                "row": 0,
+                "col": 2
+            },
+            {
+                "row": 1,
+                "col": 0
+            },
+            {
+                "row": 1,
+                "col": 1
+            },
+            {
+                "row": 1,
+                "col": 2
+            },
+            {
+                "row": 2,
+                "col": 0
+            },
+            {
+                "row": 2,
+                "col": 1
+            },
+            {
+                "row": 2,
+                "col": 2
+            }
+        ], 
+        "coordinate": [
+        {
+            "row": 0,
+            "col": 1
+        },
+        {
+            "row": 1,
+            "col": 1
+        },
+        {
+            "row": 2,
+            "col": 1
+        }
+    ],
         "board": [
             [0, 0, 0, 0],
             [0, 0, 0, 0],
@@ -340,22 +462,107 @@ const testRotateShape = [
             [0, 0, 0, 0],
             [0, 0, 0, 0],
         ],
-        "expected": [{"row": 0, "col": 1}, {"row": 1, "col": 1}, {"row": 2, "col": 1}, {"row": 3, "col": 1}]
+        "expected": [
+            {
+                "row": 1,
+                "col": 2
+            },
+            {
+                "row": 1,
+                "col": 1
+            },
+            {
+                "row": 1,
+                "col": 0
+            }
+    ]
     },
     {
         "name": "rotate a L shape",
-        "coordinate": [{"row": 0, "col": 1}, {"row": 1, "col": 1}, {"row": 2, "col": 1}, {"row": 2, "col": 2}],
+        "box": [
+        {
+            "row": 0,
+            "col": 0
+        },
+        {
+            "row": 0,
+            "col": 1
+        },
+        {
+            "row": 0,
+            "col": 2
+        },
+        {
+            "row": 1,
+            "col": 0
+        },
+        {
+            "row": 1,
+            "col": 1
+        },
+        {
+            "row": 1,
+            "col": 2
+        },
+        {
+            "row": 2,
+            "col": 0
+        },
+        {
+            "row": 2,
+            "col": 1
+        },
+        {
+            "row": 2,
+            "col": 2
+        }
+    ],
+        "coordinate": [
+            {
+                "row": 0,
+                "col": 1
+            },
+            {
+                "row": 1,
+                "col": 1
+            },
+            {
+                "row": 2,
+                "col": 0
+            },
+            {
+                "row": 2,
+                "col": 1
+            }
+    ],
         "board": [
             [0, 0, 0],
             [0, 0, 0],
             [0, 0, 0],
         ],
-        "expected": [{"row": 0, "col": 2}, {"row": 1, "col": 0}, {"row": 1, "col": 1}, {"row": 1, "col": 2}],
+        "expected": [
+            {
+                "row": 1,
+                "col": 2
+            },
+            {
+                "row": 1,
+                "col": 1
+            },
+            {
+                "row": 0,
+                "col": 0
+            },
+            {
+                "row": 1,
+                "col": 0
+            }
+],
     }
 ]
 describe('test if shape can be rotated correctly', ()=>{
-    test.each(testRotateShape)('$name', ({name, coordinate, board, expected}) => {
-        const result = rotateShape(coordinate)
+    test.each(testRotateShape)('$name', ({name, coordinate, box, board, expected}) => {
+        const result = rotateShape(coordinate, box)
         console.debug('Debug info - current shape on the board:');
         debugShapePosition(coordinate, board).forEach(row => console.debug(row.join(' ')));
         console.debug('Debug info - new shape on the board:');

--- a/app/components/MoveShape/index.tsx
+++ b/app/components/MoveShape/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import './index.scss';
 import { updateBoard, cleanUpBoard } from '../Board/util'
-import { ifInBorder, mapShapeToPositions, ifOccupy, findNextShape} from './util';
+import { ifInBorder, mapShapeToPositions, ifOccupy, findNextShape, saveBox} from './util';
 import { randomShapeGenerator } from '../Shape/util';
 
 
@@ -12,12 +12,15 @@ type MoveShapeProps = {
   rowLimit: number;
   colLimit: number;
   setBoard: (value: number[][]) => void;
+  setBorderBox: (value: number[][]) => void;
+  borderBox: number[][];
 
 };
 
-const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, rowLimit, colLimit}) => {
+const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, setBorderBox, borderBox, rowLimit, colLimit}) => {
   //coordinate of shape that is currently being moved
   const [shapeCoordinate, setShapeCoordinate] = useState(mapShapeToPositions(shape));
+  const [box, setBorderCoordinate] = useState(saveBox(shape));
   const [hasInitialized, setHasInitialized] = useState(false);
 
   //after click on "start game"
@@ -25,13 +28,13 @@ const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, 
   useEffect(() => {
     if (!hasInitialized && shape.length > 0) {
       console.log('starting again......')
-      const nextShape = findNextShape("", shapeCoordinate)
+      const nextShape = findNextShape("", shapeCoordinate, box, setBorderCoordinate);
       const {newBoard, shapePos} = updateBoard({board: board, newShape: nextShape});
-      setShapeCoordinate(shapePos)
+      setShapeCoordinate(shapePos);
       setBoard(newBoard);
       setHasInitialized(true); // ensure it only runs once
     }
-  }, [shape, hasInitialized]);
+  }, [shape, hasInitialized, box]);
 
 
   useEffect(() => {
@@ -41,7 +44,7 @@ const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, 
     let intervalId: NodeJS.Timeout;
 
     intervalId = setInterval(() => {
-      const nextShape = findNextShape("ArrowDown", shapeCoordinate);
+      const nextShape = findNextShape("ArrowDown", shapeCoordinate, box, setBorderCoordinate);
       const inBorder = ifInBorder({nextShape: nextShape, rowLimit: rowLimit, colLimit: colLimit});
       const cleanedBoard = cleanUpBoard({board, shapeCoordinate});
       const Occupied = ifOccupy({nextShape, board: cleanedBoard});
@@ -64,6 +67,7 @@ const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, 
         //restart a new shape
         var newShape = randomShapeGenerator()
         setShape(newShape);
+        setBorderCoordinate(saveBox(newShape));
         setShapeCoordinate(mapShapeToPositions(newShape))
         setHasInitialized(false);
       }
@@ -73,7 +77,7 @@ const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, 
     const handleKeyDown = (e: KeyboardEvent) => {
       e.preventDefault();
       
-      const nextShape = findNextShape(e.key, shapeCoordinate);
+      const nextShape = findNextShape(e.key, shapeCoordinate, box, setBorderCoordinate);
       const inBorder = ifInBorder({nextShape: nextShape, rowLimit: rowLimit, colLimit: colLimit});
       const cleanedBoard = cleanUpBoard({board, shapeCoordinate});
       const Occupied = ifOccupy({nextShape, board: cleanedBoard});

--- a/app/components/MoveShape/util.ts
+++ b/app/components/MoveShape/util.ts
@@ -163,8 +163,6 @@ function getPivot(shapeCoordinate: shapePositionType[]): shapePositionType{
  * @returns {shapePositionType[]} - Returns positions of the rotated shape
 */
 export function rotateShape(shapeCoordinate: shapePositionType[], box: shapePositionType[]): shapePositionType[]{
-  console.log("box", box)
-  console.log("shape coordinate", shapeCoordinate)
   const pivot = getPivot(box);
 
   //row is vertical position while col is horizontal position 

--- a/app/components/MoveShape/util.ts
+++ b/app/components/MoveShape/util.ts
@@ -81,35 +81,40 @@ export function findOccupant(nextShape: shapePositionType[], board: number[][]):
   return false
 }
 
+
 /**
  * Computes the next shape coordinates based on a user activity. 
- * If the next shape is out of bound, return undefined
- *
- * @param {string} activity - The action to perform (e.g. 'ArrowDown', 'ArrowLeft', 'ArrowRight').
- * @param {shapePositionType[]} shapeCoordinate - Array of current shape positions (each with row and col).
- * @returns {shapePositionType[]} New array of shape positions after movement
+ * If the next shape is out of bounds, returns undefined.
+ * @param {string} activity - The action to perform (e.g., 'ArrowDown', 'ArrowLeft', 'ArrowRight').
+ * @param {shapePositionType[]} shapeCoordinate - Current coordinates of the shape (each with row and col).
+ * @param {shapePositionType[]} box - The bounding box of the current shape.
+ * @param {(value: shapePositionType[]) => void} setBorderBoxCoordinate - Callback to update the border box coordinates.
+ * @returns {shapePositionType[]} New coordinates of the shape after movement
  */
-export function findNextShape(activity: string, shapeCoordinate: shapePositionType[]): shapePositionType[]{
-
+export function findNextShape(activity: string, shapeCoordinate: shapePositionType[], box: shapePositionType[], setBorderBoxCoordinate:(value: shapePositionType[]) => void): shapePositionType[]{
   const moveLeft =  (points: shapePositionType[]) => points.map(p => ({ "row": p["row"], "col": p["col"]-1 }));
   const moveRight =  (points: shapePositionType[]) => points.map(p => ({ "row": p["row"], "col": p["col"]+1 }));
   const moveDown =  (points: shapePositionType[]) => points.map(p => ({ "row": p["row"]+1, "col": p["col"] }));
 
   let moved = shapeCoordinate;
+  let newBox = box; 
 
   if (activity === 'ArrowRight') {
     moved = moveRight(shapeCoordinate);
+    newBox = moveRight(box);
   } 
   else if (activity === 'ArrowLeft') {
     moved = moveLeft(shapeCoordinate);
+    newBox = moveLeft(box);
   } 
   else if (activity === 'ArrowDown') {
     moved = moveDown(shapeCoordinate);
+    newBox = moveDown(box);
   }
   else if (activity == 'ArrowUp'){
-    moved = rotateShape(shapeCoordinate);
+    moved = rotateShape(shapeCoordinate, box);
   }
-
+  setBorderBoxCoordinate(newBox);
   return moved
 }
 
@@ -134,91 +139,57 @@ export function ifOccupy({nextShape, board}: ifOccupyParams): boolean|undefined 
   }
 
   return result
-
-  }
-
-
-
-/**
- * Rotate the shape clock wise
- * @param {shapePositionType[]} params.shapeCoordinate - Current coordinates of the shape
- * @returns {shapePositionType} - Returns the pivot point if it's on the shape; otherwise, uses the second point on the shape as the pivot point. 
-*/
-function getPivot(shapeCoordinate: shapePositionType[]): shapePositionType{
-  const rows = shapeCoordinate.map(cell => cell.row);
-  const cols = shapeCoordinate.map(cell => cell.col);
-  
-  const rowCenter = (Math.min(...rows) + Math.max(...rows)) / 2;
-  const colCenter = (Math.min(...cols) + Math.max(...cols)) / 2;
-
-  //if pivot point does not exist on the shape, then just use the second point as "pivot" point
-  if (shapeCoordinate.includes({row: rowCenter, col: colCenter })){
-    return { row: rowCenter, col: colCenter }
-  }
-  else{
-    return shapeCoordinate[1]
-  }
 }
 
 /**
- * Identify O shape
- * @param {shapePositionType[]} params.shapeCoordinate - Current coordinates of the shape
- * @returns {boolean} - Returns True if the shape is an O shape; otherwise return False
+ * Determines the pivot point for rotating a shape clockwise.
+ * @param {shapePositionType[]} shapeCoordinate - Current coordinates of the shape.
+ * @returns {shapePositionType} The pivot point if it is part of the shape; otherwise, the second point in the shape is used as the pivot point.
 */
-function identifyO(shapeCoordinate: shapePositionType[]): boolean {
-  const startPoint = shapeCoordinate[0]
-  const squareShape: shapePositionType[] = [
-    startPoint,
-    {"row": startPoint["row"], "col": startPoint["col"]+1},
-    {"row": startPoint["row"]+1, "col": startPoint["col"]},
-    {"row": startPoint["row"]+1, "col": startPoint["col"]+1},
-  ]
-  return JSON.stringify(squareShape) == JSON.stringify(shapeCoordinate)
+function getPivot(shapeCoordinate: shapePositionType[]): shapePositionType{
+  const rows = shapeCoordinate.map(cell => cell.row); // vertical positions
+  const cols = shapeCoordinate.map(cell => cell.col); // horizontal positions
+
+  const rowCenter = (Math.min(...rows) + Math.max(...rows)) / 2;
+  const colCenter = (Math.min(...cols) + Math.max(...cols)) / 2;
+
+  return { row: rowCenter, col: colCenter };
 }
 
 /**
  * Rotate a shape
- * @param {shapePositionType[]} params.shapeCoordinate - coordinates of the current shape
+ * @param {shapePositionType[]} shapeCoordinate - coordinates of the current shape
+ * @param {shapePositionType[]} box  - The grid or boxes that define the boundaries.
  * @returns {shapePositionType[]} - Returns positions of the rotated shape
 */
-export function rotateShape(shapeCoordinate: shapePositionType[]): shapePositionType[]{
-  //do not rotate O shape
-  if (identifyO(shapeCoordinate)){
-    return shapeCoordinate
-  }
-  //find a fixed pivot point
-  const pivot = getPivot(shapeCoordinate);
-  
-  function normalizeZero(x: number):number {
-  return x === 0 ? 0 : x;
-}
-  //subtract its coordinate from each cell
-  let relativeCells = shapeCoordinate.map(cell => ({
-    row: cell.row - pivot.row,
-    col: cell.col - pivot.col
-  }));
+export function rotateShape(shapeCoordinate: shapePositionType[], box: shapePositionType[]): shapePositionType[]{
+  console.log("box", box)
+  console.log("shape coordinate", shapeCoordinate)
+  const pivot = getPivot(box);
 
-  let rotatedCells = relativeCells.map(cell => ({
-    row: normalizeZero(-cell.col),
-    col: normalizeZero(cell.row)
-  }));
+  //row is vertical position while col is horizontal position 
+  const cx = pivot["col"];
+  const cy = pivot["row"];
 
-  var final = rotatedCells.map(cell => ({
-  row: cell.row + pivot.row,
-  col: cell.col + pivot.col})
-);
-  //sort keys based on row, col of the new shape, modify input in place
-  final.sort((a, b) => {
-    if (a.row !== b.row) {
-      return a.row - b.row;
-    } else {
-      return a.col - b.col;
-    }
-  });
+  var rotated = shapeCoordinate.map(cell => ({
+  row: Math.round(cy + (cell.col - cx)),   // y' = cy - (x - cx)
+  col: Math.round(cx - (cell.row - cy))    // x' = cx + (y - cy)
+}));
 
-  return final
+console.log("rotated", rotated)
+
+return rotated
+
 }
 
+/**
+ * Checks if a given shape is within the board.
+ * @param {MoveCheckParams} params
+ * @param {shapePositionType[]} params.nextShape - Coordinates of the shape to check.
+ * @param {number} params.rowLimit - Maximum number of rows in the grid.
+ * @param {number} params.colLimit - Maximum number of columns in the grid.
+ * @returns {boolean} True if the shape is entirely within the border; otherwise, false.
+ */
 export function ifInBorder({nextShape, rowLimit, colLimit}: MoveCheckParams): boolean {
   const [edgeMaxRow, edgeMaxCol, edgeMinRow, edgeMinCol] = computeBorder(nextShape);
   return edgeMaxRow < rowLimit && edgeMaxCol < colLimit && edgeMinCol >= 0 && edgeMinRow >= 0
@@ -227,7 +198,7 @@ export function ifInBorder({nextShape, rowLimit, colLimit}: MoveCheckParams): bo
 /**
  * Turn raw matrix to position of the shape on a given board
  *
- * @param {number[][]} params.matrix - shape on the board
+ * @param {number[][]} matrix - shape on the board
  * @returns {shapePositionType[]} return the position of a shape on the board
  */
 export function mapShapeToPositions(matrix: number[][]): shapePositionType[] {
@@ -242,4 +213,22 @@ export function mapShapeToPositions(matrix: number[][]): shapePositionType[] {
   });
 
   return positions;
+}
+
+/**
+ * Save the whole box including the shape and the white space
+ *
+ * @param {number[][]} matrix - shape on the board
+ * @returns {shapePositionType[]} return the position of the whole border box
+ */
+export function saveBox(matrix: number[][]): shapePositionType[] {
+  const borderBox: shapePositionType[] = [];
+
+  matrix.forEach((row, rowIndex) => {
+    row.forEach((cell, colIndex) => {
+        borderBox.push({ row: rowIndex, col: colIndex });
+    });
+  });
+
+  return borderBox;
 }

--- a/app/components/MoveShape/util.ts
+++ b/app/components/MoveShape/util.ts
@@ -174,8 +174,6 @@ export function rotateShape(shapeCoordinate: shapePositionType[], box: shapePosi
   col: Math.round(cx - (cell.row - cy))    // x' = cx + (y - cy)
 }));
 
-console.log("rotated", rotated)
-
 return rotated
 
 }

--- a/app/components/Shape/util.ts
+++ b/app/components/Shape/util.ts
@@ -1,137 +1,169 @@
-// the L shape family
 export function createLShape1(): number[][]{
-    return [[1, 0],
-            [1, 0],
-            [1, 1]];
+    return [[1, 0, 0],
+            [1, 1, 1],
+            [0, 0, 0]];
 };
 export function createLShape2(): number[][]{
-    return [[1, 1, 1],
-            [1, 0, 0]];
+    return [[0, 1, 1],
+            [0, 1, 0],
+            [0, 1, 0]
+        ];
 };
-
 export function createLShape3(): number[][]{
-    return [[1, 1],
-            [0, 1],
-            [0, 1]];
+    return [[0, 0, 0],
+            [1, 1, 1],
+            [0, 0, 1]
+        ];
 };
 export function createLShape4(): number[][]{
-    return [[0, 0, 1],
-            [1, 1, 1]];
+    return [[0, 1, 0],
+            [0, 1, 0],
+            [1, 1, 0]
+        ];
 };
 
 
 //the S shape family
 export function createSShape1(): number[][]{
-    return [[0, 1, 1],
-            [1, 1, 0]]; 
+    return [[1, 1, 0],
+            [0, 1, 1],
+            [0, 0, 0],
+        ]; 
 }
 export function createSShape2(): number[][]{
-    return [[1, 0],
-            [1, 1],
-            [0, 1]
+    return [[0, 0, 1],
+            [0, 1, 1],
+            [0, 1, 0]
             ]; 
 }
 export function createSShape3(): number[][]{
-    return [[0, 1, 1],
+    return [[0, 0, 0],
             [1, 1, 0],
+            [0, 1, 1],
             ]; 
 }
 export function createSShape4(): number[][]{
-    return [[1, 0],
-            [1, 1],
-            [0, 1],
+    return [[0, 1, 0],
+            [1, 1, 0],
+            [1, 0, 0],
             ]; 
 }
 
 //the Z shape
 export function createZShape1(): number[][]{
-    return [[1, 1, 0],
-            [0, 1, 1]]; 
+    return [
+        [0, 1, 1],
+        [1, 1, 0],
+        [0, 0, 0]
+
+    ]; 
 }
 export function createZShape2(): number[][]{
-    return [[0, 1],
-            [1, 1],
-            [1, 0]
-        ]; 
+    return [
+        [0, 1, 0],
+        [0, 1, 1],
+        [0, 0, 1]
+
+    ]; 
 }
 export function createZShape3(): number[][]{
-    return [[1, 1, 0],
-            [0, 1, 1],
-        ]; 
+    return [
+        [0, 0, 0],
+        [0, 1, 1],
+        [1, 1, 0]
+
+    ]; 
 }
 export function createZShape4(): number[][]{
-    return [[0, 1],
-            [1, 1],
-            [1, 0],
+        return [
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 1, 0]
+
         ]; 
 }
 //the J shape
 export function createJShape1(): number[][]{
-    return [[1, 1, 1],
-            [0, 0, 1]]
+    return [
+        [0, 0, 1],
+        [1, 1, 1],
+        [0, 0, 0]
+        ]
 };
 export function createJShape2(): number[][]{
-    return [[0, 1],
-            [0, 1],
-            [1, 1],
+    return [
+        [0, 1, 0],
+        [0, 1, 0],
+        [0, 1, 1]
         ]
 };
 export function createJShape3(): number[][]{
     return [
-            [1, 0, 0],
-            [1, 1, 1],
+        [0, 0, 0],
+        [1, 1, 1],
+        [1, 0, 0]
         ]
 };
 export function createJShape4(): number[][]{
     return [
-            [1, 1],
-            [1, 0],
-            [1, 0]
+        [1, 1, 0],
+        [0, 1, 0],
+        [0, 1, 0]
         ]
 };
 //the O shape
 export function createSquareShape1(): number[][]{
-    return [[1, 1],
-            [1, 1]]; 
+    return [
+        [1, 1, 1],
+        [1, 1, 1],
+        [1, 1, 1],
+
+        ]; 
 }
 
 //The I shape family
 export function createIShape1(): number[][]{
-    return [[1],
-            [1],
-            [1],
-            [1]
+    return [
+        [0, 0, 0],
+        [1, 1, 1],
+        [0, 0, 0],
         ]; 
 }
 export function createIShape2(): number[][]{
-    return [[1, 1, 1, 1]]; 
+    return [
+        [0, 1, 0],
+        [0, 1, 0],
+        [0, 1, 0],
+        ]; 
 }
 
 //The T shape family
 export function createTShape1(): number[][]{
     return [
-            [1, 1, 1],
             [0, 1, 0],
+            [1, 1, 1],
+            [0, 0, 0],
         ]
 };
 export function createTShape2(): number[][]{
     return [
-            [0, 1],
-            [1, 1],
-            [0, 1],
+            [0, 1, 0],
+            [0, 1, 1],
+            [0, 1, 0],
         ]
 };
 export function createTShape3(): number[][]{
     return [
+            [0, 0, 0],
+            [1, 1, 1],
             [0, 1, 0],
-            [1, 1, 1]
         ]
 };
 export function createTShape4(): number[][]{
     return [
-            [1, 0],
-            [1, 1],
-            [1, 0],
+            [0, 1, 0],
+            [1, 1, 0],
+            [0, 1, 0],
         ]
 };
 const allShapesFunctions = [
@@ -198,7 +230,7 @@ const shapeRegistry: { [key: string]: () => number[][] } = {
     createZShape4,
     //O shape family
     createSquareShape1,
-};
+}
 
 export function randomShapeGenerator(): number[][] {
     let randomShape:string = allShapesFunctions[Math.floor(Math.random() * allShapesFunctions.length)];

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -26,13 +26,14 @@ const initBoard = createBoard()
 export default function Home() {
   const [randomShape, setShape] = useState<number[][]>([]);
   const [board, setBoard] = useState<number[][]>(initBoard);
+  const [borderBox, setBorderBox] = useState<number[][]>([]);
 
   return (
   <div>
       <Welcome onUpdate={setShape}/>
       <div className="main-container">
         <div className="shape-container">
-        {randomShape.length > 0 && (<MoveShape setShape={setShape} shape={randomShape} setBoard={setBoard} board={board} rowLimit={ROWS} colLimit={COLS}/>)}
+        {randomShape.length > 0 && (<MoveShape setShape={setShape} shape={randomShape} setBorderBox={setBorderBox} borderBox={borderBox} setBoard={setBoard} board={board} rowLimit={ROWS} colLimit={COLS}/>)}
         </div>
 
         <Board board={ board } />


### PR DESCRIPTION
## Problem
Previously, when I rotated the shapes, they sometimes shifted upward or behaved unpredictably. This happened because of the way I was choosing the rotation center: the code would first try to locate the geometric center of a shape, but if that point wasn’t actually part of the shape, it would fall back to using the “second” piece as the center instead. 

##Solution
Based on the post here: https://gamedev.stackexchange.com/questions/208367/how-is-rotation-defined-in-a-tetris-game, I realized that it is best to have the shapes rotate in a 3*3 box
