### PR TITLE
feat: clear board and count scores 

### DIFF
--- a/app/components/MoveShape/__tests__/util.test.ts
+++ b/app/components/MoveShape/__tests__/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { computeBorder, findOccupant, ifOccupy, ifInBorder, mapShapeToPositions, rotateShape, debugShapePosition } from '../util';
+import { computeBorder, findOccupant, ifOccupy, mapShapeToPositions, rotateShape, debugShapePosition, clearBoardCountScore } from '../util';
 
 const testShapes = [
     {
@@ -567,6 +567,79 @@ describe('test if shape can be rotated correctly', ()=>{
         debugShapePosition(coordinate, board).forEach(row => console.debug(row.join(' ')));
         console.debug('Debug info - new shape on the board:');
         debugShapePosition(result, board).forEach(row => console.debug(row.join(' ')));
+        expect(result).toEqual(expected);
+      });
+})
+
+const testClearBoardCountScore = [
+    {
+        //all two rows should be cleared
+        "board": [
+            [0, 0, 0, 0, 0],
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0],
+        ],
+        "score": 0,
+        "expected": [
+        20,
+        [
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+        ],
+        ]
+    },
+    {
+        //all two rows should be cleared
+        //and one row should be moved down by 1
+        "board": [
+            [0, 0, 0, 0, 0],
+            [1, 1, 1, 1, 1],
+            [0, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0],
+        ],
+        "score": 10,
+        "expected": [
+        30,
+        [
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0],
+        ], 
+        ]
+    },
+    {
+        //Two rows should be moved down by 1
+        "board": [
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 1, 1],
+            [1, 1, 0, 1, 1],
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 0, 0]
+        ],
+        "score": 0,
+        "expected": [
+        10,
+        [
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 1, 1],
+            [1, 1, 0, 1, 1],
+            [1, 1, 1, 0, 0],
+        ]
+        ]
+    }
+]
+
+describe('test if shape can be rotated correctly', ()=>{
+    test.each(testClearBoardCountScore)('$name', ({board, score, expected}) => {
+        const result = clearBoardCountScore(board, score)
+        console.log(result)
         expect(result).toEqual(expected);
       });
 })

--- a/app/components/MoveShape/__tests__/util.test.ts
+++ b/app/components/MoveShape/__tests__/util.test.ts
@@ -639,7 +639,6 @@ const testClearBoardCountScore = [
 describe('test if shape can be rotated correctly', ()=>{
     test.each(testClearBoardCountScore)('$name', ({board, score, expected}) => {
         const result = clearBoardCountScore(board, score)
-        console.log(result)
         expect(result).toEqual(expected);
       });
 })

--- a/app/components/MoveShape/index.tsx
+++ b/app/components/MoveShape/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import './index.scss';
 import { updateBoard, cleanUpBoard } from '../Board/util'
-import { ifInBorder, mapShapeToPositions, ifOccupy, findNextShape, saveBox} from './util';
+import { ifInBorder, mapShapeToPositions, ifOccupy, findNextShape, saveBox, clearBoardCountScore} from './util';
 import { randomShapeGenerator } from '../Shape/util';
 
 
@@ -13,11 +13,13 @@ type MoveShapeProps = {
   colLimit: number;
   setBoard: (value: number[][]) => void;
   setBorderBox: (value: number[][]) => void;
+  score: number;
+  setScore: (value: number) => void;
   borderBox: number[][];
 
 };
 
-const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, setBorderBox, borderBox, rowLimit, colLimit}) => {
+const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, score, setScore, borderBox, setBorderBox, rowLimit, colLimit}) => {
   //coordinate of shape that is currently being moved
   const [shapeCoordinate, setShapeCoordinate] = useState(mapShapeToPositions(shape));
   const [box, setBorderCoordinate] = useState(saveBox(shape));
@@ -64,7 +66,12 @@ const MoveShape: React.FC<MoveShapeProps> = ({setShape, shape, setBoard, board, 
           newShape: shapeCoordinate,
         });
         setBoard(newBoard);
-        //restart a new shape
+        // also calculate if a shape needs to be cleared
+        const [newScore, updatedBoard] = clearBoardCountScore(newBoard, score);
+        setScore(newScore);
+        setBoard(updatedBoard);
+
+        // restart a new shape
         var newShape = randomShapeGenerator()
         setShape(newShape);
         setBorderCoordinate(saveBox(newShape));

--- a/app/components/MoveShape/util.ts
+++ b/app/components/MoveShape/util.ts
@@ -240,7 +240,7 @@ export function clearBoardCountScore(board: number[][], score: number): [number,
   const newBoard = board.map(row => [...row]);
   
   for (let i = 0; i < board.length; i++) {
-    const allFilled = <T>(arr: T[]): boolean => arr.every(val => val === arr[0] && val === 1);
+    const allFilled = <T>(arr: T[]): boolean => arr.every(val => val === 1);
     //mark rows that need to be removed
     const filled = allFilled(board[i])
     if (filled){

--- a/app/components/MoveShape/util.ts
+++ b/app/components/MoveShape/util.ts
@@ -21,6 +21,7 @@ const OCCUPIED_CELL = 1
  * @returns {number[][]} - return the new board with the shape
  */
 export function debugShapePosition(position: shapePositionType[], board: number[][]): number[][]{
+  console.log(board)
   const newBoard = board.map(row => [...row])
 
   position.forEach(dot => {
@@ -132,12 +133,6 @@ export function ifOccupy({nextShape, board}: ifOccupyParams): boolean|undefined 
 
   const result = findOccupant(nextShape, newBoard);
 
-  if (result && nextShape && process.env.NODE_ENV !== 'production') {
-    console.debug('Debug info - nextShape on the board:');
-    debugShapePosition(nextShape, board).forEach(row => console.debug(row.join(' ')));
-    console.debug('Debug info - findOccupant:', findOccupant(nextShape, newBoard));
-  }
-
   return result
 }
 
@@ -226,4 +221,50 @@ export function saveBox(matrix: number[][]): shapePositionType[] {
   });
 
   return borderBox;
+}
+
+/**
+ * Clears fully filled rows in a Tetris-like board and returns the updated score and board.
+ *
+ * A row is considered "filled" if all its cells contain `1`. 
+ * Cleared rows are either removed or reset to zeros depending on implementation.
+ * The score can be incremented based on the number of cleared rows.
+ *
+ * @param {number[][]} board - The current game board, represented as a 2D array of numbers.
+ * @param {number} score - The current score before clearing any rows.
+ * @returns {[number, number[][]]} - A tuple containing:
+ *    1. The updated score.
+ *    2. The updated board after clearing filled rows.
+ */
+export function clearBoardCountScore(board: number[][], score: number): [number, number[][]]{
+  let rowsToClear: number[] = [];
+  var newBoard = board.map(row => [...row]);
+  
+  for (let i = 0; i < board.length; i++) {
+    const allFilled = <T>(arr: T[]): boolean => arr.every(val => val === arr[0] && val === 1);
+    //mark rows that need to be removed
+    const filled = allFilled(board[i])
+    if (filled){
+      rowsToClear.push(i)
+    }
+  }
+  //sort index
+  rowsToClear.sort((a, b) => b - a);
+
+  //remove rows
+  //have to start from the bigger indexs
+  if (rowsToClear.length > 0){
+    for (let i of rowsToClear) {
+      newBoard.splice(i, 1);
+    }
+    //add empty rows back to the top
+    let numCols = board[0].length;
+    for (let i = 0; i < rowsToClear.length; i++) {
+      newBoard.unshift(Array(numCols).fill(0));
+    }
+  }
+
+  score = score + 10 * rowsToClear.length
+
+  return [score, newBoard]
 }

--- a/app/components/MoveShape/util.ts
+++ b/app/components/MoveShape/util.ts
@@ -236,8 +236,8 @@ export function saveBox(matrix: number[][]): shapePositionType[] {
  *    2. The updated board after clearing filled rows.
  */
 export function clearBoardCountScore(board: number[][], score: number): [number, number[][]]{
-  let rowsToClear: number[] = [];
-  var newBoard = board.map(row => [...row]);
+  const rowsToClear: number[] = [];
+  const newBoard = board.map(row => [...row]);
   
   for (let i = 0; i < board.length; i++) {
     const allFilled = <T>(arr: T[]): boolean => arr.every(val => val === arr[0] && val === 1);

--- a/app/components/MoveShape/util.ts
+++ b/app/components/MoveShape/util.ts
@@ -21,7 +21,6 @@ const OCCUPIED_CELL = 1
  * @returns {number[][]} - return the new board with the shape
  */
 export function debugShapePosition(position: shapePositionType[], board: number[][]): number[][]{
-  console.log(board)
   const newBoard = board.map(row => [...row])
 
   position.forEach(dot => {

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -13,8 +13,8 @@ export function meta({}: Route.MetaArgs) {
   ];
 }
 
-const ROWS = 20;
-const COLS = 30;
+const ROWS = 15;
+const COLS = 10;
 
 // initialize board with 0s (empty cells)
 const createBoard = () => {
@@ -27,13 +27,14 @@ export default function Home() {
   const [randomShape, setShape] = useState<number[][]>([]);
   const [board, setBoard] = useState<number[][]>(initBoard);
   const [borderBox, setBorderBox] = useState<number[][]>([]);
+  const [score, setScore] = useState(0);
 
   return (
   <div>
-      <Welcome onUpdate={setShape}/>
+      <Welcome onUpdate={setShape} score={score}/>
       <div className="main-container">
         <div className="shape-container">
-        {randomShape.length > 0 && (<MoveShape setShape={setShape} shape={randomShape} setBorderBox={setBorderBox} borderBox={borderBox} setBoard={setBoard} board={board} rowLimit={ROWS} colLimit={COLS}/>)}
+        {randomShape.length > 0 && (<MoveShape setShape={setShape} shape={randomShape} setBoard={setBoard} board={board} score={score} setBorderBox={setBorderBox} setScore={setScore} borderBox={borderBox} rowLimit={ROWS} colLimit={COLS}/>)}
         </div>
 
         <Board board={ board } />

--- a/app/welcome/welcome.tsx
+++ b/app/welcome/welcome.tsx
@@ -4,9 +4,10 @@ import StartGameButton from "../components/StartGameButton";
 // Define the type for the props
 type WelcomeProp = {
   onUpdate: (value: number[][]) => void;
+  score: number;
 }
 
-const Welcome: React.FC<WelcomeProp> = ({ onUpdate }) => {
+const Welcome: React.FC<WelcomeProp> = ({ onUpdate, score }) => {
   const disabled = false
 
   return (
@@ -15,6 +16,10 @@ const Welcome: React.FC<WelcomeProp> = ({ onUpdate }) => {
         <header className="flex flex-col items-start gap-5 w-[500px] max-w-[100vw] p-4">
           <div>
             Welcome to tetris!
+          </div>
+
+          <div>
+            Score: {score}
           </div>
 
           <div>


### PR DESCRIPTION
# Problem
Currently, when a row is filled, we don't clear that row. This PR is to enable this feature

# Solution 
The thought process: 
* Step 1: Make a copy of the matrix
* Step 2: loop through the matrix and record what rows have been filled
* Step 3: Document the index of rows that need to be removed and removed them in the copy (starting from the bigger index)
* Step 4: Insert new rows on top in the copy 
* Step 5: calculate score and return new board